### PR TITLE
Deny claiming the designated token

### DIFF
--- a/contracts/ExitModule.sol
+++ b/contracts/ExitModule.sol
@@ -84,7 +84,7 @@ contract Exit is Module {
 
         address previousToken;
         for (uint8 i = 0; i < tokens.length; i++) {
-            require(!deniedTokens[tokens[i]], "Invalid token");
+            require(!deniedTokens[tokens[i]] && tokens[i] != address(designatedToken), "Denied token");
             require(
                 tokens[i] > previousToken,
                 "tokens[] is out of order or contains a duplicate"

--- a/test/01_ExitModule.spec.ts
+++ b/test/01_ExitModule.spec.ts
@@ -235,6 +235,22 @@ describe("Exit", async () => {
       ).to.be.revertedWith(`Denied token`);
     });
 
+    it("throws if designated token is in list", async () => {
+      const { avatar, module, tokenOne, tokenTwo, designatedToken } =
+        await setupTestWithTestAvatar();
+      const data = module.interface.encodeFunctionData("addToDenylist", [
+        [tokenOne.address],
+      ]);
+      await avatar.exec(module.address, 0, data);
+
+      await avatar.setModule(module.address);
+      await designatedToken.approve(module.address, DesignatedTokenBalance);
+
+      await expect(
+        module.exit(DesignatedTokenBalance, [designatedToken.address])
+      ).to.be.revertedWith(`Denied token`);
+    });
+
     it("throws because user is trying to redeem more tokens than he owns", async () => {
       const { avatar, module, tokenOne, tokenTwo } =
         await setupTestWithTestAvatar();

--- a/test/01_ExitModule.spec.ts
+++ b/test/01_ExitModule.spec.ts
@@ -232,7 +232,7 @@ describe("Exit", async () => {
           tokenOne.address,
           tokenTwo.address,
         ])
-      ).to.be.revertedWith(`Invalid token`);
+      ).to.be.revertedWith(`Denied token`);
     });
 
     it("throws because user is trying to redeem more tokens than he owns", async () => {

--- a/test/02_CirculatingSupply.spec.ts
+++ b/test/02_CirculatingSupply.spec.ts
@@ -26,10 +26,10 @@ describe("CirculatingSupply", async () => {
       designatedToken.address,
       [avatar.address]
     );
-    await user1.sendTransaction({ to: avatar.address, value: 100 });
-    await designatedToken.mint(avatar.address, 100);
-    await designatedToken.mint(user1.address, 100);
-    await designatedToken.mint(user2.address, 100);
+    expect(user1.sendTransaction({ to: avatar.address, value: 100 }));
+    expect(designatedToken.mint(avatar.address, 100));
+    expect(designatedToken.mint(user1.address, 100));
+    expect(designatedToken.mint(user2.address, 100));
 
     const initializeParams = new AbiCoder().encode(
       ["address", "address", "address[]"],
@@ -215,7 +215,9 @@ describe("CirculatingSupply", async () => {
 
     it("returns circulating supply with multiple exclusions", async () => {
       const { circulatingSupply } = await setupTests();
-      circulatingSupply.exclude(user1.address);
+      expect(circulatingSupply.exclude(user1.address))
+        .to.emit(circulatingSupply, "ExclusionAdded")
+        .withArgs(user1.address);
       expect(await circulatingSupply.get()).to.be.equals(100);
     });
   });
@@ -265,6 +267,9 @@ describe("CirculatingSupply", async () => {
 
     it("reverts if exclusion is already enabled", async () => {
       const { circulatingSupply } = await setupTests();
+      expect(circulatingSupply.exclude(user1.address))
+        .to.emit(circulatingSupply, "ExclusionAdded")
+        .withArgs(user1.address);
       expect(circulatingSupply.exclude(user1.address)).to.be.revertedWith(
         "Exclusion already enabled"
       );


### PR DESCRIPTION
This PR proposes to disallow claiming the designated token in the exit function.

It's likely the avatar holds a balance of the designated token. So when redeeming this token via the Exit contract the user could claim and receive a share of this same token from the avatar's current balance. This in itself is a bit strange, but there are even some edge cases where you will receive more tokens than you redeem. (If the token balance locked in the avatar is greater than the circulating supply.)

It seems safer to just generally deny claiming the designated token. This way users won't have to remember adding it to the deny list. 