### PR TITLE
fix: updates the base URL of the safe client service

### DIFF
--- a/packages/exit-app/src/services/safeTransactionApi.ts
+++ b/packages/exit-app/src/services/safeTransactionApi.ts
@@ -2,7 +2,7 @@ import axios from 'axios'
 import { SafeAssets, TokenAsset } from '../store/main/models'
 
 export class SafeTransactionApi {
-  private baseUrl = 'https://safe-client.gnosis.io'
+  private baseUrl = 'https://safe-client.safe.global'
   private chainId: number
   private safe: string
 


### PR DESCRIPTION
This PR updates the base URL for the safe client service, as the former URL no longer works.